### PR TITLE
feat: add ability to change timeout

### DIFF
--- a/my-seq-logger/src/seq_logger.rs
+++ b/my-seq-logger/src/seq_logger.rs
@@ -37,14 +37,17 @@ impl SeqLogger {
         }));
 
         let mut inner = SeqLoggerInner::new(settings.clone());
-        if let Some(queue_size) = SeqLoggerSettings::read(&settings).await.queue_size {
+        let settings = SeqLoggerSettings::read(&settings).await;
+
+        if let Some(queue_size) = settings.queue_size {
             inner.configure(queue_size)
         }
 
         let mut result = Self {
             app_states: AppStates::create_initialized().into(),
             inner: Arc::new(inner),
-            events_loop: EventsLoop::new("SeqLogger".to_string(), my_logger_core::LOGGER.clone()),
+            events_loop: EventsLoop::new("SeqLogger".to_string(), my_logger_core::LOGGER.clone())
+                .set_iteration_timeout(settings.timeout),
         };
 
         result.events_loop.register_event_loop(result.inner.clone());

--- a/my-seq-logger/src/seq_logger_inner.rs
+++ b/my-seq-logger/src/seq_logger_inner.rs
@@ -40,7 +40,7 @@ impl EventsLoopTick<()> for SeqLoggerInner {
 
         let populated_params = my_logger_core::LOGGER.get_populated_params().await;
 
-        let fl_url_uploader = FlUrlUploader::new(settings.url, settings.api_key);
+        let fl_url_uploader = FlUrlUploader::new(settings.url, settings.api_key, settings.timeout);
 
         crate::upload_logs_chunk::upload_log_events_chunk(
             &fl_url_uploader,

--- a/my-seq-logger/src/settings.rs
+++ b/my-seq-logger/src/settings.rs
@@ -7,6 +7,7 @@ pub trait SeqSettings {
 
 const DEFAULT_FLUSH_SLEEP: u64 = 1;
 const DEFAULT_FLUSH_CHUNK: usize = 50;
+const DEFAULT_TIMEOUT: u64 = 10;
 
 pub struct SeqLoggerSettings {
     pub url: String,
@@ -14,6 +15,7 @@ pub struct SeqLoggerSettings {
     pub max_logs_flush_chunk: usize,
     pub flush_delay: Duration,
     pub queue_size: Option<usize>,
+    pub timeout: Duration,
 }
 
 impl SeqLoggerSettings {
@@ -37,6 +39,7 @@ impl SeqLoggerSettings {
         let mut max_logs_flush_chunk = DEFAULT_FLUSH_CHUNK;
         let mut flush_delay = DEFAULT_FLUSH_SLEEP;
         let mut queue_size = None;
+        let mut timeout = DEFAULT_TIMEOUT;
 
         for item in conn_string.split(';') {
             let (key, value) = spit_key_value(item);
@@ -59,6 +62,9 @@ impl SeqLoggerSettings {
                 "queuesize" => {
                     queue_size = Some(value.parse::<usize>().expect("QueueSize must be a number"));
                 }
+                "timeout" => {
+                    timeout = value.parse::<u64>().expect("Timeout must be a number");
+                }
                 _ => {
                     panic!("Invalid key {} of seq connection string ", key);
                 }
@@ -77,6 +83,7 @@ impl SeqLoggerSettings {
             max_logs_flush_chunk,
             flush_delay: Duration::from_secs(flush_delay),
             queue_size,
+            timeout: Duration::from_secs(timeout),
         };
 
         Ok(result)

--- a/my-seq-logger/src/uploader.rs
+++ b/my-seq-logger/src/uploader.rs
@@ -14,15 +14,17 @@ pub struct FlUrlUploader {
     pub api_key: Option<String>,
     pub seq_debug: bool,
     pub compress: bool,
+    pub timeout: Duration,
 }
 
 impl FlUrlUploader {
-    pub fn new(url: String, api_key: Option<String>) -> Self {
+    pub fn new(url: String, api_key: Option<String>, timeout: Duration) -> Self {
         Self {
             url,
             api_key,
             seq_debug: std::env::var("SEQ_DEBUG").is_ok(),
             compress: std::env::var("SEQ_COMPRESS").is_ok(),
+            timeout,
         }
     }
 }
@@ -42,7 +44,7 @@ impl LogsChunkUploader for FlUrlUploader {
             }
 
             let mut fl_url = FlUrl::new(self.url.as_str())
-                .set_timeout(Duration::from_secs(10))
+                .set_timeout(self.timeout)
                 .append_path_segment("api")
                 .append_path_segment("events")
                 .append_path_segment("raw")


### PR DESCRIPTION
Adds a timeout configuration parameter and synchronizes Flurl and event tick timeouts.
Previously, the event tick used a 5s timeout while Flurl used 10s, causing premature tick timeouts during requests.